### PR TITLE
Use the Arduino IoT Cloud Library with debug enabled

### DIFF
--- a/arduino/enable-debug-on-iotcloudlibrary.md
+++ b/arduino/enable-debug-on-iotcloudlibrary.md
@@ -1,0 +1,63 @@
+# Enable debug on IoT Cloud Library
+
+
+Visit https://github.com/arduino-libraries/ArduinoIoTCloud/ and clone the repo on your computer.
+
+Edit the `src/AIoTC_Config.h:65` https://github.com/arduino-libraries/ArduinoIoTCloud/blob/master/src/AIoTC_Config.h#L65 and uncomment the `Debug.print()`.
+
+
+```git
+diff --git a/src/AIoTC_Config.h b/src/AIoTC_Config.h
+index 9ceb2ac..6df348a 100644
+--- a/src/AIoTC_Config.h
++++ b/src/AIoTC_Config.h
+@@ -62,7 +62,7 @@
+ # if defined(ARDUINO_AVR_UNO_WIFI_REV2)
+ #   define DEBUG_VERBOSE(fmt, ...)
+ # else
+-#   define DEBUG_VERBOSE(fmt, ...) //Debug.print(DBG_VERBOSE, fmt, ## __VA_ARGS__)
++#   define DEBUG_VERBOSE(fmt, ...) Debug.print(DBG_VERBOSE, fmt, ## __VA_ARGS__)
+ # endif
+ #endif
+``` 
+
+Create a ZIP file with the whole library folder:
+```shell
+$ zip -r ArduinoIoTCloud-with-debug.zip ArduinoIoTCloud
+```
+
+You’ll end up with a 4.9M file.
+
+Visit https://create-dev.arduino.cc/editor
+
+Libraries > Custom 
+
+Click on the icon and upload your custom version of the library.
+
+
+Great! Starting from now, every time you build a sketch that requires the IoTCloudLibrary this custom version will be used!
+
+Run a new “verify and upload” using an Over-the-Air device, and now you will see additional information in the Serial Monitor, like the following output:
+
+```
+ArduinoIoTCloudTCP::onOTARequest _ota_url = https://api-dev.arduino.cc/iot/ota/a0cd5030-fae0-4ede-aa4d-63d971ebfa71
+***** Arduino IoT Cloud - configuration info *****
+Device ID: ba38d0c7-9bcc-412f-8073-cd6e28afa41a
+Thing ID: 08f67265-01be-48a1-aa50-a1d1bf9462a4
+MQTT Broker: mqtts-sa.iot.oniudra.cc:8883
+WiFi.status(): 0
+Current WiFi Firmware: 1.4.8
+Connected to "Middle Earth"
+ArduinoIoTCloudTCP::handle_SyncTime internal clock configured to posix timestamp 1634916888
+Connected to Arduino IoT Cloud
+ArduinoIoTCloudTCP::handle_RequestLastValues [13876] last values requested
+ArduinoIoTCloudTCP::handleMessage [15886] last values received
+
+```
+
+## Attach to the serial
+
+```shell
+$ socat -s stdio /dev/cu.usbmodem2101
+```
+

--- a/arduino/enable-debug-on-iotcloudlibrary.md
+++ b/arduino/enable-debug-on-iotcloudlibrary.md
@@ -14,7 +14,22 @@ Create a ZIP file with the whole library folder:
 $ zip -r ArduinoIoTCloud-with-debug.zip ArduinoIoTCloud
 ```
 
-You’ll end up with a 4.9M file.
+You’ll end up with a 4.9M file named `ArduinoIoTCloud-with-debug.zip` with the following content:
+
+```shell
+# Prints the content of the ZIP file to double check its content structure.
+$ unzip -l ArduinoIoTCloud-with-debug.zip | tail
+16655  08-11-2020 20:51   ArduinoIoTCloud/extras/test/src/test_callback.cpp
+ 3472  08-11-2020 20:51   ArduinoIoTCloud/extras/test/src/test_CloudLocation.cpp
+ 2277  08-11-2020 20:51   ArduinoIoTCloud/extras/test/src/test_publishOnChangeRateLimit.cpp
+  907  08-11-2020 20:51   ArduinoIoTCloud/extras/test/src/test_writeOnly.cpp
+ 1095  08-11-2020 20:51   ArduinoIoTCloud/extras/test/src/test_readOnly.cpp
+ 1996  08-11-2020 20:51   ArduinoIoTCloud/extras/test/src/test_publishEvery.cpp
+ 1560  08-11-2020 20:51   ArduinoIoTCloud/extras/test/src/test_publishOnChange.cpp
+26082  10-22-2021 16:53   ArduinoIoTCloud/extras/test/src/test_encode.cpp
+---------                     -------
+7447543                     1352 files
+```
 
 Visit https://create.arduino.cc/editor and click on Libraries > Custom.
 

--- a/arduino/enable-debug-on-iotcloudlibrary.md
+++ b/arduino/enable-debug-on-iotcloudlibrary.md
@@ -24,9 +24,11 @@ Great! Starting from now, every time you build a sketch that requires the IoTClo
 
 TIP: remove this custom library after the tests, or you won't get new updates to the original library.
 
-Run a new “verify and upload” using an Over-the-Air device, and now you will see additional information in the Serial Monitor, like the following output:
+Run a new “verify and upload” using an Over-the-Air device, and now you will see additional information in the Serial Monitor, like the following output (this is a successful OTA update):
 
 ```
+## Comment: board 1st boot
+
 ***** Arduino IoT Cloud - configuration info *****
 Device ID: ba38d0c7-9bcc-412f-8073-cd6e28afa41a
 Thing ID: 08f67265-01be-48a1-aa50-a1d1bf9462a4
@@ -44,10 +46,20 @@ ArduinoIoTCloudTCP::handle_SubscribeMqttTopics subscribed to /a/t/08f67265-01be-
 Connected to Arduino IoT Cloud
 ArduinoIoTCloudTCP::handle_RequestLastValues [12890] last values requested
 ArduinoIoTCloudTCP::handleMessage [15899] last values received
+
+## Comment: 1st boot completed, now the sketch is running.
+
+... time passes ...
+
+## Comment: I click on “verify and upload” and the OTA process starts
+
 ArduinoIoTCloudTCP::onOTARequest _ota_url = https://api-dev.arduino.cc/iot/ota/732ccdfb-89dd-43e2-9206-a9bbb947b984
 ArduinoIoTCloudTCP::samd_onOTARequest downloading to nina: https://api-dev.arduino.cc/iot/ota/732ccdfb-89dd-43e2-9206-a
 ArduinoIoTCloudTCP::samd_onOTARequest download successful
 ArduinoIoTCloudTCP::samd_onOTARequest performing reset to reboot
+
+## Comment: the board resets
+
 ***** Arduino IoT Cloud - configuration info *****
 Device ID: ba38d0c7-9bcc-412f-8073-cd6e28afa41a
 Thing ID: 08f67265-01be-48a1-aa50-a1d1bf9462a4
@@ -65,6 +77,8 @@ ArduinoIoTCloudTCP::handle_SubscribeMqttTopics subscribed to /a/t/08f67265-01be-
 Connected to Arduino IoT Cloud
 ArduinoIoTCloudTCP::handle_RequestLastValues [14629] last values requested
 ArduinoIoTCloudTCP::handleMessage [17639] last values received
+
+## Comment: the process completed successfully.
 ```
 
 ## How to access the serial port from the terminal

--- a/arduino/enable-debug-on-iotcloudlibrary.md
+++ b/arduino/enable-debug-on-iotcloudlibrary.md
@@ -1,46 +1,32 @@
 # Enable debug on IoT Cloud Library
 
+As of today, the [ArduinoIoTCloud](https://github.com/arduino-libraries/ArduinoIoTCloud) library does not have any specific verbose logs the trace step in the Over-the-Air (OTA) update process.
 
-Visit https://github.com/arduino-libraries/ArduinoIoTCloud/ and clone the repo on your computer.
+I created a [fork](https://github.com/zmoog/ArduinoIoTCloud) of the library with a few additional log statements.
 
-Edit the `src/AIoTC_Config.h:65` https://github.com/arduino-libraries/ArduinoIoTCloud/blob/master/src/AIoTC_Config.h#L65 and uncomment the `Debug.print()`.
+Visit https://github.com/zmoog/ArduinoIoTCloud, clone the repo on your computer and check out the `zmoog/more-logs-in-ota-process` branch.
 
-
-```git
-diff --git a/src/AIoTC_Config.h b/src/AIoTC_Config.h
-index 9ceb2ac..6df348a 100644
---- a/src/AIoTC_Config.h
-+++ b/src/AIoTC_Config.h
-@@ -62,7 +62,7 @@
- # if defined(ARDUINO_AVR_UNO_WIFI_REV2)
- #   define DEBUG_VERBOSE(fmt, ...)
- # else
--#   define DEBUG_VERBOSE(fmt, ...) //Debug.print(DBG_VERBOSE, fmt, ## __VA_ARGS__)
-+#   define DEBUG_VERBOSE(fmt, ...) Debug.print(DBG_VERBOSE, fmt, ## __VA_ARGS__)
- # endif
- #endif
-``` 
+## Prepare the library fork
 
 Create a ZIP file with the whole library folder:
+
 ```shell
 $ zip -r ArduinoIoTCloud-with-debug.zip ArduinoIoTCloud
 ```
 
 You’ll end up with a 4.9M file.
 
-Visit https://create-dev.arduino.cc/editor
+Visit https://create.arduino.cc/editor and click on Libraries > Custom.
 
-Libraries > Custom 
-
-Click on the icon and upload your custom version of the library.
-
+Click on the icon, and upload your custom version of the library.
 
 Great! Starting from now, every time you build a sketch that requires the IoTCloudLibrary this custom version will be used!
+
+TIP: remove this custom library after the tests, or you won't get new updates to the original library.
 
 Run a new “verify and upload” using an Over-the-Air device, and now you will see additional information in the Serial Monitor, like the following output:
 
 ```
-ArduinoIoTCloudTCP::onOTARequest _ota_url = https://api-dev.arduino.cc/iot/ota/a0cd5030-fae0-4ede-aa4d-63d971ebfa71
 ***** Arduino IoT Cloud - configuration info *****
 Device ID: ba38d0c7-9bcc-412f-8073-cd6e28afa41a
 Thing ID: 08f67265-01be-48a1-aa50-a1d1bf9462a4
@@ -48,16 +34,56 @@ MQTT Broker: mqtts-sa.iot.oniudra.cc:8883
 WiFi.status(): 0
 Current WiFi Firmware: 1.4.8
 Connected to "Middle Earth"
-ArduinoIoTCloudTCP::handle_SyncTime internal clock configured to posix timestamp 1634916888
+ArduinoIoTCloudTCP::handle_SyncTime internal clock configured to posix timestamp 1635149042
+ArduinoIoTCloudTCP::handle_ConnectMqttBroker connecting to mqtts-sa.iot.oniudra.cc:8883 (attempt 0)
+ArduinoIoTCloudTCP::handle_ConnectMqttBroker connected to mqtts-sa.iot.oniudra.cc:8883
+ArduinoIoTCloudTCP::handle_SubscribeMqttTopics subscribing to /a/t/08f67265-01be-48a1-aa50-a1d1bf9462a4/e/i ...
+ArduinoIoTCloudTCP::handle_SubscribeMqttTopics subscribed to /a/t/08f67265-01be-48a1-aa50-a1d1bf9462a4/e/i
+ArduinoIoTCloudTCP::handle_SubscribeMqttTopics subscribing to /a/t/08f67265-01be-48a1-aa50-a1d1bf9462a4/shadow/i ...
+ArduinoIoTCloudTCP::handle_SubscribeMqttTopics subscribed to /a/t/08f67265-01be-48a1-aa50-a1d1bf9462a4/shadow/i
 Connected to Arduino IoT Cloud
-ArduinoIoTCloudTCP::handle_RequestLastValues [13876] last values requested
-ArduinoIoTCloudTCP::handleMessage [15886] last values received
-
+ArduinoIoTCloudTCP::handle_RequestLastValues [12890] last values requested
+ArduinoIoTCloudTCP::handleMessage [15899] last values received
+ArduinoIoTCloudTCP::onOTARequest _ota_url = https://api-dev.arduino.cc/iot/ota/732ccdfb-89dd-43e2-9206-a9bbb947b984
+ArduinoIoTCloudTCP::samd_onOTARequest downloading to nina: https://api-dev.arduino.cc/iot/ota/732ccdfb-89dd-43e2-9206-a
+ArduinoIoTCloudTCP::samd_onOTARequest download successful
+ArduinoIoTCloudTCP::samd_onOTARequest performing reset to reboot
+***** Arduino IoT Cloud - configuration info *****
+Device ID: ba38d0c7-9bcc-412f-8073-cd6e28afa41a
+Thing ID: 08f67265-01be-48a1-aa50-a1d1bf9462a4
+MQTT Broker: mqtts-sa.iot.oniudra.cc:8883
+WiFi.status(): 0
+Current WiFi Firmware: 1.4.8
+Connected to "Middle Earth"
+ArduinoIoTCloudTCP::handle_SyncTime internal clock configured to posix timestamp 1635154511
+ArduinoIoTCloudTCP::handle_ConnectMqttBroker connecting to mqtts-sa.iot.oniudra.cc:8883 (attempt 0)
+ArduinoIoTCloudTCP::handle_ConnectMqttBroker connected to mqtts-sa.iot.oniudra.cc:8883
+ArduinoIoTCloudTCP::handle_SubscribeMqttTopics subscribing to /a/t/08f67265-01be-48a1-aa50-a1d1bf9462a4/e/i ...
+ArduinoIoTCloudTCP::handle_SubscribeMqttTopics subscribed to /a/t/08f67265-01be-48a1-aa50-a1d1bf9462a4/e/i
+ArduinoIoTCloudTCP::handle_SubscribeMqttTopics subscribing to /a/t/08f67265-01be-48a1-aa50-a1d1bf9462a4/shadow/i ...
+ArduinoIoTCloudTCP::handle_SubscribeMqttTopics subscribed to /a/t/08f67265-01be-48a1-aa50-a1d1bf9462a4/shadow/i
+Connected to Arduino IoT Cloud
+ArduinoIoTCloudTCP::handle_RequestLastValues [14629] last values requested
+ArduinoIoTCloudTCP::handleMessage [17639] last values received
 ```
 
-## Attach to the serial
+## How to access the serial port from the terminal
+
+Personally, during these troubleshooting sessions I use the `minicom` utility.
+
+Get the port currently used by the board:
 
 ```shell
-$ socat -s stdio /dev/cu.usbmodem2101
+$ arduino-cli board list
+Port                            Protocol Type              Board Name          FQBN                     Core
+/dev/cu.URT0                    serial   Unknown
+/dev/cu.usbmodem1101            serial   Serial Port (USB) Arduino NANO 33 IoT arduino:samd:nano_33_iot arduino:samd
 ```
 
+Open minicom using the serial port `/dev/cu.usbmodem1101`:
+
+```shell
+$ minicom -D /dev/cu.usbmodem1101
+```
+
+- [Is there an OS X terminal program that can access serial ports?](https://apple.stackexchange.com/questions/32834/is-there-an-os-x-terminal-program-that-can-access-serial-ports)

--- a/arduino/get-more-logs-out-of-the-arduino-iot-cloud-library.md
+++ b/arduino/get-more-logs-out-of-the-arduino-iot-cloud-library.md
@@ -121,5 +121,3 @@ Device ID: ba38d0c7-9bcc-412f-8073-cd6e28afa41a
 [2021-10-26 10:51:14] ArduinoIoTCloudTCP::handleMessage [18089] last values received
 
 ```
-
-- [Is there an OS X terminal program that can access serial ports?](https://apple.stackexchange.com/questions/32834/is-there-an-os-x-terminal-program-that-can-access-serial-ports)

--- a/arduino/get-more-logs-out-of-the-arduino-iot-cloud-library.md
+++ b/arduino/get-more-logs-out-of-the-arduino-iot-cloud-library.md
@@ -32,6 +32,8 @@ Great! Starting from now, every time you build a sketch that requires the IoTClo
 
 TIP: remove this custom library after the test, or you won't get new updates to the original library.
 
+## Upload and Run the Sketch on the Board
+
 Run a new “verify and upload” using an Over-the-Air device, and now you will see additional information in the Serial Monitor, like the following output (this is a successful OTA update):
 
 ```

--- a/arduino/get-more-logs-out-of-the-arduino-iot-cloud-library.md
+++ b/arduino/get-more-logs-out-of-the-arduino-iot-cloud-library.md
@@ -1,6 +1,6 @@
 # Get More Logs out of the Arduino IoTCloudLibrary
 
-As of today, the [ArduinoIoTCloud](https://github.com/arduino-libraries/ArduinoIoTCloud) library does not have any specific verbose logs, so trace complex workflows like Over-the-Air (OTA) update process can become quite challenging.
+As of today, the [ArduinoIoTCloud](https://github.com/arduino-libraries/ArduinoIoTCloud) library does not have any specific verbose logs, so tracing complex workflows like the Over-the-Air (OTA) update process can become quite challenging.
 
 I created a humble [fork](https://github.com/zmoog/ArduinoIoTCloud) of the library, with just a very few additional log statements.
 
@@ -26,7 +26,7 @@ setDebugMessageLevel(4);
 
 Visit https://create.arduino.cc/editor and click on Libraries > Custom.
 
-Click on the icon, and upload your custom version of the library.
+Click on the import icon (near the "Library Manager" button), and upload your custom version of the library.
 
 Great! Starting from now, every time you build a sketch that requires the IoTCloudLibrary this custom version will be used!
 

--- a/arduino/get-more-logs-out-of-the-arduino-iot-cloud-library.md
+++ b/arduino/get-more-logs-out-of-the-arduino-iot-cloud-library.md
@@ -37,54 +37,58 @@ Run a new “verify and upload” using an Over-the-Air device, and now you will
 ```
 ## Comment: board 1st boot
 
-***** Arduino IoT Cloud - configuration info *****
-Device ID: ba38d0c7-9bcc-412f-8073-cd6e28afa41a
-Thing ID: 08f67265-01be-48a1-aa50-a1d1bf9462a4
-MQTT Broker: mqtts-sa.iot.oniudra.cc:8883
-WiFi.status(): 0
-Current WiFi Firmware: 1.4.8
-Connected to "Middle Earth"
-ArduinoIoTCloudTCP::handle_SyncTime internal clock configured to posix timestamp 1635149042
-ArduinoIoTCloudTCP::handle_ConnectMqttBroker connecting to mqtts-sa.iot.oniudra.cc:8883 (attempt 0)
-ArduinoIoTCloudTCP::handle_ConnectMqttBroker connected to mqtts-sa.iot.oniudra.cc:8883
-ArduinoIoTCloudTCP::handle_SubscribeMqttTopics subscribing to /a/t/08f67265-01be-48a1-aa50-a1d1bf9462a4/e/i ...
-ArduinoIoTCloudTCP::handle_SubscribeMqttTopics subscribed to /a/t/08f67265-01be-48a1-aa50-a1d1bf9462a4/e/i
-ArduinoIoTCloudTCP::handle_SubscribeMqttTopics subscribing to /a/t/08f67265-01be-48a1-aa50-a1d1bf9462a4/shadow/i ...
-ArduinoIoTCloudTCP::handle_SubscribeMqttTopics subscribed to /a/t/08f67265-01be-48a1-aa50-a1d1bf9462a4/shadow/i
-Connected to Arduino IoT Cloud
-ArduinoIoTCloudTCP::handle_RequestLastValues [12890] last values requested
-ArduinoIoTCloudTCP::handleMessage [15899] last values received
+[2021-10-26 11:48:22] ***** Arduino IoT Cloud - configuration info *****
+[2021-10-26 11:48:22] Device ID: 46854c56-8237-49a6-93d7-217be67b1951
+[2021-10-26 11:48:22] Thing ID: 298a6dc2-4018-46cd-9255-6b6c6a5007a0
+[2021-10-26 11:48:22] MQTT Broker: mqtts-sa.iot.arduino.cc:8883
+[2021-10-26 11:48:22] WiFi.status(): 0
+[2021-10-26 11:48:22] Current WiFi Firmware: 1.4.8
+[2021-10-26 11:48:26] Connected to "Middle Earth"
+[2021-10-26 11:48:26] ArduinoIoTCloudTCP::handle_SyncTime internal clock configured to posix timestamp 1635241707
+[2021-10-26 11:48:27] ArduinoIoTCloudTCP::handle_ConnectMqttBroker connecting to mqtts-sa.iot.arduino.cc:8883 (attempt 0)
+[2021-10-26 11:48:30] ArduinoIoTCloudTCP::handle_ConnectMqttBroker connected to mqtts-sa.iot.arduino.cc:8883
+[2021-10-26 11:48:34] Sd card not detected
+[2021-10-26 11:48:34] ArduinoIoTCloudTCP::handle_SubscribeMqttTopics subscribing to /a/t/298a6dc2-4018-46cd-9255-6b6c6a5007a0/e/i ...
+[2021-10-26 11:48:35] ArduinoIoTCloudTCP::handle_SubscribeMqttTopics subscribed to /a/t/298a6dc2-4018-46cd-9255-6b6c6a5007a0/e/i
+[2021-10-26 11:48:35] ArduinoIoTCloudTCP::handle_SubscribeMqttTopics subscribing to /a/t/298a6dc2-4018-46cd-9255-6b6c6a5007a0/shadow/i ...
+[2021-10-26 11:48:35] ArduinoIoTCloudTCP::handle_SubscribeMqttTopics subscribed to /a/t/298a6dc2-4018-46cd-9255-6b6c6a5007a0/shadow/i
+[2021-10-26 11:48:35] Connected to Arduino IoT Cloud
+[2021-10-26 11:48:35] ArduinoIoTCloudTCP::handle_RequestLastValues [15670] last values requested
+[2021-10-26 11:48:37] ArduinoIoTCloudTCP::handleMessage [17497] last values received
 
 ## Comment: 1st boot completed, now the sketch is running.
 
+
 ... time passes ...
+
 
 ## Comment: I click on “verify and upload” and the OTA process starts
 
-ArduinoIoTCloudTCP::onOTARequest _ota_url = https://api-dev.arduino.cc/iot/ota/732ccdfb-89dd-43e2-9206-a9bbb947b984
-ArduinoIoTCloudTCP::samd_onOTARequest downloading to nina: https://api-dev.arduino.cc/iot/ota/732ccdfb-89dd-43e2-9206-a
-ArduinoIoTCloudTCP::samd_onOTARequest download successful
-ArduinoIoTCloudTCP::samd_onOTARequest performing reset to reboot
+[2021-10-26 11:50:30] ArduinoIoTCloudTCP::onOTARequest _ota_url = https://api2.arduino.cc/iot/ota/38d59aee-e004-4dd7-8b79-716c4e7678dc
+[2021-10-26 11:50:30] ArduinoIoTCloudTCP::samd_onOTARequest downloading to nina: https://api2.arduino.cc/iot/ota/38d59aee-e004-4dd7-8b79-716c
+[2021-10-26 11:50:44] ArduinoIoTCloudTCP::samd_onOTARequest download successful
+[2021-10-26 11:50:44] ArduinoIoTCloudTCP::samd_onOTARequest performing reset to reboot
 
 ## Comment: the board resets
 
-***** Arduino IoT Cloud - configuration info *****
-Device ID: ba38d0c7-9bcc-412f-8073-cd6e28afa41a
-Thing ID: 08f67265-01be-48a1-aa50-a1d1bf9462a4
-MQTT Broker: mqtts-sa.iot.oniudra.cc:8883
-WiFi.status(): 0
-Current WiFi Firmware: 1.4.8
-Connected to "Middle Earth"
-ArduinoIoTCloudTCP::handle_SyncTime internal clock configured to posix timestamp 1635154511
-ArduinoIoTCloudTCP::handle_ConnectMqttBroker connecting to mqtts-sa.iot.oniudra.cc:8883 (attempt 0)
-ArduinoIoTCloudTCP::handle_ConnectMqttBroker connected to mqtts-sa.iot.oniudra.cc:8883
-ArduinoIoTCloudTCP::handle_SubscribeMqttTopics subscribing to /a/t/08f67265-01be-48a1-aa50-a1d1bf9462a4/e/i ...
-ArduinoIoTCloudTCP::handle_SubscribeMqttTopics subscribed to /a/t/08f67265-01be-48a1-aa50-a1d1bf9462a4/e/i
-ArduinoIoTCloudTCP::handle_SubscribeMqttTopics subscribing to /a/t/08f67265-01be-48a1-aa50-a1d1bf9462a4/shadow/i ...
-ArduinoIoTCloudTCP::handle_SubscribeMqttTopics subscribed to /a/t/08f67265-01be-48a1-aa50-a1d1bf9462a4/shadow/i
-Connected to Arduino IoT Cloud
-ArduinoIoTCloudTCP::handle_RequestLastValues [14629] last values requested
-ArduinoIoTCloudTCP::handleMessage [17639] last values received
+[2021-10-26 11:51:04] ***** Arduino IoT Cloud - configuration info *****
+[2021-10-26 11:51:04] Device ID: 46854c56-8237-49a6-93d7-217be67b1951
+[2021-10-26 11:51:04] Thing ID: 298a6dc2-4018-46cd-9255-6b6c6a5007a0
+[2021-10-26 11:51:04] MQTT Broker: mqtts-sa.iot.arduino.cc:8883
+[2021-10-26 11:51:04] WiFi.status(): 0
+[2021-10-26 11:51:04] Current WiFi Firmware: 1.4.8
+[2021-10-26 11:51:08] Connected to "Middle Earth"
+[2021-10-26 11:51:08] ArduinoIoTCloudTCP::handle_SyncTime internal clock configured to posix timestamp 1635241868
+[2021-10-26 11:51:09] ArduinoIoTCloudTCP::handle_ConnectMqttBroker connecting to mqtts-sa.iot.arduino.cc:8883 (attempt 0)
+[2021-10-26 11:51:12] ArduinoIoTCloudTCP::handle_ConnectMqttBroker connected to mqtts-sa.iot.arduino.cc:8883
+[2021-10-26 11:51:16] Sd card not detected
+[2021-10-26 11:51:16] ArduinoIoTCloudTCP::handle_SubscribeMqttTopics subscribing to /a/t/298a6dc2-4018-46cd-9255-6b6c6a5007a0/e/i ...
+[2021-10-26 11:51:16] ArduinoIoTCloudTCP::handle_SubscribeMqttTopics subscribed to /a/t/298a6dc2-4018-46cd-9255-6b6c6a5007a0/e/i
+[2021-10-26 11:51:16] ArduinoIoTCloudTCP::handle_SubscribeMqttTopics subscribing to /a/t/298a6dc2-4018-46cd-9255-6b6c6a5007a0/shadow/i ...
+[2021-10-26 11:51:17] ArduinoIoTCloudTCP::handle_SubscribeMqttTopics subscribed to /a/t/298a6dc2-4018-46cd-9255-6b6c6a5007a0/shadow/i
+[2021-10-26 11:51:17] Connected to Arduino IoT Cloud
+[2021-10-26 11:51:17] ArduinoIoTCloudTCP::handle_RequestLastValues [15249] last values requested
+[2021-10-26 11:51:18] ArduinoIoTCloudTCP::handleMessage [16648] last values received
 
 ## Comment: the process completed successfully.
 ```
@@ -111,22 +115,22 @@ $ minicom -D /dev/cu.usbmodem1101
 TIP: Pressing `Meta-N` on the `minicom` console you also get a nice timestamp on each line:
 
 ```
-***** Arduino IoT Cloud - configuration info *****
-Device ID: ba38d0c7-9bcc-412f-8073-cd6e28afa41a
-[2021-10-26 10:50:59] Thing ID: 08f67265-01be-48a1-aa50-a1d1bf9462a4
-[2021-10-26 10:50:59] MQTT Broker: mqtts-sa.iot.oniudra.cc:8883
-[2021-10-26 10:50:59] WiFi.status(): 0
-[2021-10-26 10:50:59] Current WiFi Firmware: 1.4.8
-[2021-10-26 10:51:03] Connected to "Middle Earth"
-[2021-10-26 10:51:04] ArduinoIoTCloudTCP::handle_SyncTime internal clock configured to posix timestamp 1635238264
-[2021-10-26 10:51:05] ArduinoIoTCloudTCP::handle_ConnectMqttBroker connecting to mqtts-sa.iot.oniudra.cc:8883 (attempt 0)
-[2021-10-26 10:51:08] ArduinoIoTCloudTCP::handle_ConnectMqttBroker connected to mqtts-sa.iot.oniudra.cc:8883
-[2021-10-26 10:51:09] ArduinoIoTCloudTCP::handle_SubscribeMqttTopics subscribing to /a/t/08f67265-01be-48a1-aa50-a1d1bf9462a4/e/i ...
-[2021-10-26 10:51:09] ArduinoIoTCloudTCP::handle_SubscribeMqttTopics subscribed to /a/t/08f67265-01be-48a1-aa50-a1d1bf9462a4/e/i
-[2021-10-26 10:51:09] ArduinoIoTCloudTCP::handle_SubscribeMqttTopics subscribing to /a/t/08f67265-01be-48a1-aa50-a1d1bf9462a4/shadow/i ...
-[2021-10-26 10:51:09] ArduinoIoTCloudTCP::handle_SubscribeMqttTopics subscribed to /a/t/08f67265-01be-48a1-aa50-a1d1bf9462a4/shadow/i
-[2021-10-26 10:51:09] Connected to Arduino IoT Cloud
-[2021-10-26 10:51:10] ArduinoIoTCloudTCP::handle_RequestLastValues [14079] last values requested
-[2021-10-26 10:51:14] ArduinoIoTCloudTCP::handleMessage [18089] last values received
+[2021-10-26 11:48:22] ***** Arduino IoT Cloud - configuration info *****
+[2021-10-26 11:48:22] Device ID: 46854c56-8237-49a6-93d7-217be67b1951
+[2021-10-26 11:48:22] Thing ID: 298a6dc2-4018-46cd-9255-6b6c6a5007a0
+[2021-10-26 11:48:22] MQTT Broker: mqtts-sa.iot.arduino.cc:8883
+[2021-10-26 11:48:22] WiFi.status(): 0
+[2021-10-26 11:48:22] Current WiFi Firmware: 1.4.8
+[2021-10-26 11:48:26] Connected to "Middle Earth"
+[2021-10-26 11:48:26] ArduinoIoTCloudTCP::handle_SyncTime internal clock configured to posix timestamp 1635241707
+[2021-10-26 11:48:27] ArduinoIoTCloudTCP::handle_ConnectMqttBroker connecting to mqtts-sa.iot.arduino.cc:8883 (attempt 0)
+[2021-10-26 11:48:30] ArduinoIoTCloudTCP::handle_ConnectMqttBroker connected to mqtts-sa.iot.arduino.cc:8883
+[2021-10-26 11:48:34] ArduinoIoTCloudTCP::handle_SubscribeMqttTopics subscribing to /a/t/298a6dc2-4018-46cd-9255-6b6c6a5007a0/e/i ...
+[2021-10-26 11:48:35] ArduinoIoTCloudTCP::handle_SubscribeMqttTopics subscribed to /a/t/298a6dc2-4018-46cd-9255-6b6c6a5007a0/e/i
+[2021-10-26 11:48:35] ArduinoIoTCloudTCP::handle_SubscribeMqttTopics subscribing to /a/t/298a6dc2-4018-46cd-9255-6b6c6a5007a0/shadow/i ...
+[2021-10-26 11:48:35] ArduinoIoTCloudTCP::handle_SubscribeMqttTopics subscribed to /a/t/298a6dc2-4018-46cd-9255-6b6c6a5007a0/shadow/i
+[2021-10-26 11:48:35] Connected to Arduino IoT Cloud
+[2021-10-26 11:48:35] ArduinoIoTCloudTCP::handle_RequestLastValues [15670] last values requested
+[2021-10-26 11:48:37] ArduinoIoTCloudTCP::handleMessage [17497] last values received
 
 ```

--- a/arduino/get-more-logs-out-of-the-arduino-iot-cloud-library.md
+++ b/arduino/get-more-logs-out-of-the-arduino-iot-cloud-library.md
@@ -1,35 +1,19 @@
-# Enable debug on IoT Cloud Library
+# Get More Logs out of the Arduino IoTCloudLibrary
 
-As of today, the [ArduinoIoTCloud](https://github.com/arduino-libraries/ArduinoIoTCloud) library does not have any specific verbose logs the trace step in the Over-the-Air (OTA) update process.
+As of today, the [ArduinoIoTCloud](https://github.com/arduino-libraries/ArduinoIoTCloud) library does not have any specific verbose logs, so trace complex workflows like Over-the-Air (OTA) update process can become quite challenging.
 
-I created a [fork](https://github.com/zmoog/ArduinoIoTCloud) of the library with a few additional log statements.
+I created a humble [fork](https://github.com/zmoog/ArduinoIoTCloud) of the library, with just a very few additional log statements.
 
-Visit https://github.com/zmoog/ArduinoIoTCloud, clone the repo on your computer and check out the `zmoog/more-logs-in-ota-process` branch.
+## Get the Library Fork
 
-## Prepare the library fork
+Visit https://github.com/zmoog/ArduinoIoTCloud and:
 
-Create a ZIP file with the whole library folder:
+- select `zmoog/more-logs-in-ota-process` from the branch dropdown on the left;
+- select Code > Download ZIP from the green actions dropdown on the right;
 
-```shell
-$ zip -r ArduinoIoTCloud-with-debug.zip ArduinoIoTCloud
-```
+Save the ZIP file on your computer to use it as a custom library on the Cloud Editor.
 
-You’ll end up with a 4.9M file named `ArduinoIoTCloud-with-debug.zip` with the following content:
-
-```shell
-# Prints the content of the ZIP file to double check its content structure.
-$ unzip -l ArduinoIoTCloud-with-debug.zip | tail
-16655  08-11-2020 20:51   ArduinoIoTCloud/extras/test/src/test_callback.cpp
- 3472  08-11-2020 20:51   ArduinoIoTCloud/extras/test/src/test_CloudLocation.cpp
- 2277  08-11-2020 20:51   ArduinoIoTCloud/extras/test/src/test_publishOnChangeRateLimit.cpp
-  907  08-11-2020 20:51   ArduinoIoTCloud/extras/test/src/test_writeOnly.cpp
- 1095  08-11-2020 20:51   ArduinoIoTCloud/extras/test/src/test_readOnly.cpp
- 1996  08-11-2020 20:51   ArduinoIoTCloud/extras/test/src/test_publishEvery.cpp
- 1560  08-11-2020 20:51   ArduinoIoTCloud/extras/test/src/test_publishOnChange.cpp
-26082  10-22-2021 16:53   ArduinoIoTCloud/extras/test/src/test_encode.cpp
----------                     -------
-7447543                     1352 files
-```
+## Upload the IoTCloudLibrary as a Custom Library on the Arduino Cloud Editor
 
 Visit https://create.arduino.cc/editor and click on Libraries > Custom.
 
@@ -37,7 +21,7 @@ Click on the icon, and upload your custom version of the library.
 
 Great! Starting from now, every time you build a sketch that requires the IoTCloudLibrary this custom version will be used!
 
-TIP: remove this custom library after the tests, or you won't get new updates to the original library.
+TIP: remove this custom library after the test, or you won't get new updates to the original library.
 
 Run a new “verify and upload” using an Over-the-Air device, and now you will see additional information in the Serial Monitor, like the following output (this is a successful OTA update):
 
@@ -96,7 +80,7 @@ ArduinoIoTCloudTCP::handleMessage [17639] last values received
 ## Comment: the process completed successfully.
 ```
 
-## How to access the serial port from the terminal
+## Optional: How to access the serial port from the terminal
 
 Personally, during these troubleshooting sessions I use the `minicom` utility.
 
@@ -113,6 +97,29 @@ Open minicom using the serial port `/dev/cu.usbmodem1101`:
 
 ```shell
 $ minicom -D /dev/cu.usbmodem1101
+```
+
+TIP: Pressing `Meta-N` on the `minicom` console you also get a nice timestamp on each line:
+
+```
+***** Arduino IoT Cloud - configuration info *****
+Device ID: ba38d0c7-9bcc-412f-8073-cd6e28afa41a
+[2021-10-26 10:50:59] Thing ID: 08f67265-01be-48a1-aa50-a1d1bf9462a4
+[2021-10-26 10:50:59] MQTT Broker: mqtts-sa.iot.oniudra.cc:8883
+[2021-10-26 10:50:59] WiFi.status(): 0
+[2021-10-26 10:50:59] Current WiFi Firmware: 1.4.8
+[2021-10-26 10:51:03] Connected to "Middle Earth"
+[2021-10-26 10:51:04] ArduinoIoTCloudTCP::handle_SyncTime internal clock configured to posix timestamp 1635238264
+[2021-10-26 10:51:05] ArduinoIoTCloudTCP::handle_ConnectMqttBroker connecting to mqtts-sa.iot.oniudra.cc:8883 (attempt 0)
+[2021-10-26 10:51:08] ArduinoIoTCloudTCP::handle_ConnectMqttBroker connected to mqtts-sa.iot.oniudra.cc:8883
+[2021-10-26 10:51:09] ArduinoIoTCloudTCP::handle_SubscribeMqttTopics subscribing to /a/t/08f67265-01be-48a1-aa50-a1d1bf9462a4/e/i ...
+[2021-10-26 10:51:09] ArduinoIoTCloudTCP::handle_SubscribeMqttTopics subscribed to /a/t/08f67265-01be-48a1-aa50-a1d1bf9462a4/e/i
+[2021-10-26 10:51:09] ArduinoIoTCloudTCP::handle_SubscribeMqttTopics subscribing to /a/t/08f67265-01be-48a1-aa50-a1d1bf9462a4/shadow/i ...
+[2021-10-26 10:51:09] ArduinoIoTCloudTCP::handle_SubscribeMqttTopics subscribed to /a/t/08f67265-01be-48a1-aa50-a1d1bf9462a4/shadow/i
+[2021-10-26 10:51:09] Connected to Arduino IoT Cloud
+[2021-10-26 10:51:10] ArduinoIoTCloudTCP::handle_RequestLastValues [14079] last values requested
+[2021-10-26 10:51:14] ArduinoIoTCloudTCP::handleMessage [18089] last values received
+
 ```
 
 - [Is there an OS X terminal program that can access serial ports?](https://apple.stackexchange.com/questions/32834/is-there-an-os-x-terminal-program-that-can-access-serial-ports)

--- a/arduino/get-more-logs-out-of-the-arduino-iot-cloud-library.md
+++ b/arduino/get-more-logs-out-of-the-arduino-iot-cloud-library.md
@@ -13,6 +13,15 @@ Visit https://github.com/zmoog/ArduinoIoTCloud and:
 
 Save the ZIP file on your computer to use it as a custom library on the Cloud Editor.
 
+## Set up your Sketch
+
+Make sure your sketch is configured to use the most verbose log level:
+
+```c
+//Get Cloud Info/errors , 0 (only errors) up to 4
+setDebugMessageLevel(4);
+```
+
 ## Upload the IoTCloudLibrary as a Custom Library on the Arduino Cloud Editor
 
 Visit https://create.arduino.cc/editor and click on Libraries > Custom.


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

As of today, the officially released Arduino [IoTCloudLibrary](https://github.com/arduino-libraries/ArduinoIoTCloud) does not have any specific verbose logs the trace step in the Over-the-Air (OTA) update process.

I created a [fork](https://github.com/zmoog/ArduinoIoTCloud) of the library with just a few additional simple log statements during the main OTA update steps.

### Change description
<!-- What does your code do? -->

Describe how to use the [IoTCloudLibrary fork](https://github.com/zmoog/ArduinoIoTCloud) to print much more details about the Over-the-Air update of the sketch.

### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

* https://github.com/arduino-libraries/ArduinoIoTCloud/pull/282

### Reviewer checklist

* [ ] PR address a single concern.
* [ ] PR title and description are properly filled.
* [ ] Changes will be merged in `main`.
* [ ] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well formatted.